### PR TITLE
feat: simplify release strategy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish
+
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -11,6 +12,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'release'
     environment: production
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow trigger/condition changes only; main risk is misconfiguration that could prevent publishing or cause it not to run when expected.
> 
> **Overview**
> Updates the `Publish` GitHub Actions workflow to run **only when a PR to `main` is closed and merged**, and only if the PR source branch is `release`, replacing the previous direct `push`-to-`main` trigger.
> 
> This gates production publishing/release automation behind the `release` branch merge flow, reducing accidental publishes from regular merges to `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31c1c7c7af4103644dc2f419f8ce0403c9ba4af6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->